### PR TITLE
Add WordPress audio transcriber plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # ERZ-FORM-PRO
+
+This repository contains a simple example WordPress plugin for audio transcription.
+
+See `audio-transcriber/README.md` for details.

--- a/audio-transcriber/README.md
+++ b/audio-transcriber/README.md
@@ -1,0 +1,17 @@
+# Audio Transcriber Plugin
+
+This WordPress plugin creates a page where visitors can drag and drop an audio file to obtain a transcription.
+
+## Features
+
+- Automatically creates a page `Audio Transcriber` on activation.
+- Drag & drop upload interface using AJAX.
+- Invokes a Python script (`transcriber.py`) that attempts to transcribe the audio using the `openai-whisper` library. If Whisper is not available, it falls back to the `speech_recognition` library.
+
+## Installation
+
+1. Copy the `audio-transcriber` directory into your WordPress `wp-content/plugins` folder.
+2. Ensure Python 3 with the required libraries (`openai-whisper` and `SpeechRecognition`) is available on the server.
+   You can install them with `pip install openai-whisper SpeechRecognition`.
+3. Activate the plugin from the WordPress admin area.
+4. Visit the newly created page `Audio Transcriber` to use the transcriber.

--- a/audio-transcriber/audio-transcriber.php
+++ b/audio-transcriber/audio-transcriber.php
@@ -1,0 +1,93 @@
+<?php
+/*
+Plugin Name: Audio Transcriber
+Description: Creates a page where users can drag & drop audio files for transcription.
+Version: 0.1.0
+Author: Codex
+*/
+
+// Register activation hook to create page
+register_activation_hook(__FILE__, function() {
+    $page = array(
+        'post_title'   => 'Audio Transcriber',
+        'post_name'    => 'audio-transcriber',
+        'post_status'  => 'publish',
+        'post_type'    => 'page',
+        'post_content' => '[audio_transcriber_form]'
+    );
+    if (!get_page_by_path($page['post_name'])) {
+        wp_insert_post($page);
+    }
+});
+
+// Shortcode to display form
+add_shortcode('audio_transcriber_form', function() {
+    ob_start();
+    ?>
+    <div id="at-dropzone" style="border: 2px dashed #ccc; padding: 40px; text-align:center;">
+        <p>Drag & drop an audio file here</p>
+        <input type="file" id="at-file" accept="audio/*" style="display:none" />
+    </div>
+    <pre id="at-result"></pre>
+    <script>
+    const dropzone = document.getElementById('at-dropzone');
+    const fileInput = document.getElementById('at-file');
+    dropzone.addEventListener('dragover', e => {
+        e.preventDefault();
+        dropzone.style.background = '#eee';
+    });
+    dropzone.addEventListener('dragleave', e => {
+        dropzone.style.background = '';
+    });
+    dropzone.addEventListener('drop', e => {
+        e.preventDefault();
+        dropzone.style.background = '';
+        const file = e.dataTransfer.files[0];
+        uploadFile(file);
+    });
+    dropzone.addEventListener('click', () => fileInput.click());
+    fileInput.addEventListener('change', () => uploadFile(fileInput.files[0]));
+
+    function uploadFile(file) {
+        const formData = new FormData();
+        formData.append('action', 'at_transcribe');
+        formData.append('audio', file);
+        fetch('<?php echo admin_url('admin-ajax.php'); ?>', {
+            method: 'POST',
+            credentials: 'same-origin',
+            body: formData
+        })
+        .then(r => r.json())
+        .then(data => {
+            document.getElementById('at-result').textContent = data.text || data.error;
+        })
+        .catch(e => alert(e));
+    }
+    </script>
+    <?php
+    return ob_get_clean();
+});
+
+// Handle ajax request
+add_action('wp_ajax_at_transcribe', 'at_handle_upload');
+add_action('wp_ajax_nopriv_at_transcribe', 'at_handle_upload');
+function at_handle_upload() {
+    if (empty($_FILES['audio'])) {
+        wp_send_json(['error' => 'No file uploaded']);
+    }
+
+    $file = wp_handle_upload($_FILES['audio'], ['test_form' => false]);
+    if (isset($file['error'])) {
+        wp_send_json(['error' => $file['error']]);
+    }
+
+    $path = $file['file'];
+    $cmd = escapeshellcmd("python3 " . plugin_dir_path(__FILE__) . "transcriber.py " . escapeshellarg($path));
+    $output = shell_exec($cmd);
+
+    if (!$output) {
+        wp_send_json(['error' => 'Transcription failed']);
+    }
+    wp_send_json(['text' => $output]);
+}
+?>

--- a/audio-transcriber/transcriber.py
+++ b/audio-transcriber/transcriber.py
@@ -1,0 +1,44 @@
+import sys
+import json
+
+try:
+    import whisper
+except ImportError:
+    whisper = None
+
+try:
+    import speech_recognition as sr
+except ImportError:
+    sr = None
+
+def transcribe_whisper(path):
+    model = whisper.load_model("base")
+    result = model.transcribe(path)
+    return result.get("text", "")
+
+def transcribe_sr(path):
+    r = sr.Recognizer()
+    with sr.AudioFile(path) as source:
+        audio = r.record(source)
+    return r.recognize_google(audio)
+
+def main():
+    if len(sys.argv) < 2:
+        print("No file provided", file=sys.stderr)
+        sys.exit(1)
+    path = sys.argv[1]
+    text = ""
+    if whisper:
+        try:
+            text = transcribe_whisper(path)
+        except Exception as e:
+            text = str(e)
+    if not text and sr:
+        try:
+            text = transcribe_sr(path)
+        except Exception as e:
+            text = str(e)
+    print(text)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `audio-transcriber` WordPress plugin
- implement drag-and-drop interface using AJAX
- add Python transcriber script that tries `whisper` then falls back to `speech_recognition`
- document usage

## Testing
- `python3 -m py_compile audio-transcriber/transcriber.py`
- `php -l audio-transcriber/audio-transcriber.php`


------
https://chatgpt.com/codex/tasks/task_e_687926c218ac8328a8b35ef63c2b7c3d